### PR TITLE
Fixed condition to deploy to npm

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -28,7 +28,7 @@ jobs:
       # If local version is greater than remote next step will be executed.
       # or else the step will fail and stop from deploying to npm.
       - name: Compare local and remote version with dpkg
-        run:  dpkg --compare-versions ${{env.localVersion}} "lt" ${{env.remoteVersion}}
+        run:  dpkg --compare-versions ${{env.localVersion}} "gt" ${{env.remoteVersion}}
     
       - name : Setup node 16.x
         uses: actions/setup-node@v3


### PR DESCRIPTION
Fixed the condition to check if localVersion > remoteVersion

Validated the possible cases as per the screenshot below. The deployment proceeds only if status of the compare is 0. 1 indicates abnormal exit status.

![image](https://user-images.githubusercontent.com/161750/202642821-c684b297-135d-499d-b7b9-a258bfec654b.png)
