### PR TITLE
Added SAS URL for file Entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodets-ms-core",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nodets-ms-core",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "ISC",
       "dependencies": {
         "@azure/service-bus": "^7.7.0",

--- a/src/core/storage/abstract/storage_client.ts
+++ b/src/core/storage/abstract/storage_client.ts
@@ -17,5 +17,5 @@ export abstract class StorageClient {
 
     abstract getFileFromUrl(fullUrl:string): Promise<FileEntity>;
 
-
+    abstract getSASUrl(containerName:string, filePath:string, expiryInHours:number): Promise<string>;
  }

--- a/src/core/storage/providers/azure/azure_storage_client.ts
+++ b/src/core/storage/providers/azure/azure_storage_client.ts
@@ -1,4 +1,4 @@
-import { BlobServiceClient, RestError } from "@azure/storage-blob";
+import { BlobSASPermissions, BlobServiceClient, RestError } from "@azure/storage-blob";
 import { IStorageConfig } from "../../../../models/abstracts/istorageconfig";
 import { NotFoundResourceError } from "../../../../utils/resource-errors/not-found-resource-error";
 import { UnprocessableResourceError } from "../../../../utils/resource-errors/unprocessable-resource-error";
@@ -70,6 +70,19 @@ export class AzureStorageClient implements StorageClient {
         const containerName = fileComponents[1];
         const fileRelativePath = fileComponents.slice(2).join('/');
         return this.getFile(containerName,fileRelativePath);
+    }
+
+    getSASUrl(containerName: string, filePath: string, expiryInHours: number): Promise<string> {
+        return new Promise((resolve, reject) => {
+            // const permissions = BlobSASPermissions.from({read:true})
+            const containerClient = this._blobServiceClient.getContainerClient(containerName);
+            const blobClient = containerClient.getBlockBlobClient(filePath);
+            const sasToken = blobClient.generateSasUrl({
+                permissions: BlobSASPermissions.parse("r"),
+                expiresOn: new Date(new Date().valueOf() + 3600 * 1000 * expiryInHours)
+            });
+            resolve(sasToken);
+        });
     }
 
 }

--- a/src/core/storage/providers/local/local_storage_client.ts
+++ b/src/core/storage/providers/local/local_storage_client.ts
@@ -48,4 +48,14 @@ export class LocalStorageClient implements StorageClient {
         return this.getFile(containerName,fileRelativePath);
     }
 
+    getSASUrl(containerName: string, filePath: string, expiryInHours: number): Promise<string> {
+        return new Promise((resolve,reject)=>{
+            this.getFile(containerName,filePath).then((file)=>{
+                resolve(file.remoteUrl);
+            }).catch((e)=>{
+                reject(e);
+            });
+        });
+    }
+
 }

--- a/test/local_storage_client.unit.ts
+++ b/test/local_storage_client.unit.ts
@@ -26,7 +26,7 @@ jest.mock('../src/core/storage/providers/local/local_storage_container', () => {
             return {
                 listFiles: jest.fn().mockImplementation(() => {
                     return Promise.resolve([
-                        { fileName: 'sample1', filePath: 'sample/path1.zip' },
+                        { fileName: 'sample1', filePath: 'sample/path1.zip' , remoteUrl: 'http://localhost:3000/sample/path1.zip'},
                         { fileName: 'sample2', filePath: 'sample/path2.zip' },
                         { fileName: 'sample3', filePath: 'sample/path3.zip' }
                     ])
@@ -76,5 +76,14 @@ describe('Local storage client', () => {
         const localClient = new LocalStorageClient(host);
         // Act and Assert
         await expect(localClient.getFile('sample', 'nofile.zip')).rejects.toThrow(new NotFoundResourceError('404'));
+    })
+
+    it('Should get the SAS URL', async () => {
+        // Arrange
+        const localClient = new LocalStorageClient(host);
+        // Act
+        const sasUrl = await localClient.getSASUrl('sample', 'path1.zip', 2);
+        // Assert
+        expect(sasUrl).toBeTruthy();
     })
 })


### PR DESCRIPTION
- Added SAS URL for StorageClient.
- Added Unit tests for `getSASUrl`
Storage client has a new method called `getSASUrl` to fetch the SAS URL of a file based on the container name, full path and an expiry time.

Task ID - [Task 1001](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1001): Update core packages with SAS URL