### PR TITLE
Fixed Issue-1703

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log
 
+### v0.0.17
+- Introduced a new helper method `shouldRecreateReceiver` that inspects errors (e.g., `GeneralError`, `ServiceCommunicationError`, errors containing "Unknown error occurred", or when `retryable` is true) to determine if the receiver should be reinitialized. This change ensures that transient or fatal connection errors do not break the polling loop.
+- Instead of rejecting the promise on errors (which would break the subscription), the updated logic:
+  - Logs the error.
+  - Checks if the error warrants a receiver re-creation via `shouldRecreateReceiver`.
+  - Closes the existing receiver if needed and then reinitializes it.
+  - Continues polling after a short delay (1 second) to maintain uninterrupted message processing.
+- Changed the lock renewal interval from 30 seconds to 25 seconds. This provides a safer margin to renew locks before they expire.
+- The calling of `subscribe` and `publish` methods remain unchanged.
+    
+
 ### v0.0.16
 - Added ability to subscribe number concurrent messages (configurable). If maxConcurrentMessages is not passed then it will process the messages according to the number of CPUs.
   `Core.getTopic('topicName', configuration || null, maxConcurrentMessages=2)`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodets-ms-core",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "NodeJS Typescript Boilerplate with cloud interaction",
   "main": "lib/index.js",
   "scripts": {

--- a/src/core/queue/providers/azure-service-bus-topic.ts
+++ b/src/core/queue/providers/azure-service-bus-topic.ts
@@ -22,20 +22,28 @@ export class AzureServiceBusTopic implements IMessageTopic {
         this.sender = this.sbClient.createSender(topic);
         this.topic = topic;
         this.maxConcurrentMessages = maxConcurrentMessages;
-        this.lockRenewalTime = 30 * 1000; // 30 seconds
+        this.lockRenewalTime = 25 * 1000; // 25 seconds
     }
 
+    /**
+    * Subscribes to the given subscription using a polling loop.
+    * Instead of breaking on AMQP or connection errors,
+    * this implementation reinitializes the receiver and continues polling.
+    */
     subscribe(subscription: string, handler: ITopicSubscription): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
+                // Initialize the receiver
                 this.listener = this.sbClient.createReceiver(this.topic, subscription);
 
                 const receiveMessages = () => {
+                    // Use the current listener to receive messages
                     this.listener!
                         .receiveMessages(this.maxConcurrentMessages, { maxWaitTimeInMs: 5000 })
                         .then((messages) => {
                             if (messages.length === 0) {
-                                return receiveMessages(); // Continue processing if no messages
+                                // No messages received; continue polling
+                                return receiveMessages();
                             }
 
                             const processingPromises = messages.map((message) =>
@@ -43,12 +51,32 @@ export class AzureServiceBusTopic implements IMessageTopic {
                             );
 
                             Promise.allSettled(processingPromises).then(() => {
-                                receiveMessages(); // Continue after processing the current batch
+                                // Continue after processing the current batch
+                                receiveMessages();
                             });
                         })
-                        .catch((error) => {
+                        .catch((error: any) => {
                             console.error("Error in message processing:", error);
-                            reject(error);
+
+                            // Check if the error indicates that we need to recreate the receiver.
+                            if (this.shouldRecreateReceiver(error)) {
+                                console.log("Recreating receiver due to error:", error.message);
+                                // Instead of rejecting (which would break the subscription),
+                                // we try to close the current receiver (if it's not already closed),
+                                // reinitialize it, and continue polling.
+                                if (this.listener && !this.listener.isClosed) {
+                                    this.listener
+                                    .close()
+                                    .catch((closeErr) =>
+                                        console.error("Error closing listener:", closeErr)
+                                    );
+                                }
+                            // Re-create the receiver to recover from connection errors.
+                            this.listener = this.sbClient.createReceiver(this.topic, subscription);
+
+                            }
+                            // Optionally add a delay before retrying the polling loop.
+                            setTimeout(receiveMessages, 1000);
                         });
                 };
 
@@ -60,13 +88,31 @@ export class AzureServiceBusTopic implements IMessageTopic {
         });
     }
 
+    private shouldRecreateReceiver(error: any): boolean {
+        if (!error) return false;
+        if (error.code === "GeneralError") return true; // Usually covers ECONNRESET error.
+        if (error.name === "ServiceCommunicationError") return true;
+        if (error.message?.includes("Unknown error occurred")) return true;
+
+        // Fallback for an unknown fatal error:
+        // e.g. look for "onDetached" or "MessagingError" in the stack or message
+        if (error.retryable === true) return true;
+
+        // Adjust logic as you see fit
+        return true
+        
+    }
+
+    /**
+    * Processes a single message with manual lock renewal.
+    */
     private async processMessageWithLockRenewal(
         message: ServiceBusReceivedMessage,
         handler: ITopicSubscription
     ): Promise<void> {
         let isProcessingComplete = false;
 
-        // Start lock renewal
+        // Using setInterval for lock renewal.
         const renewalInterval = setInterval(async () => {
             if (isProcessingComplete) {
                 clearInterval(renewalInterval);
@@ -74,9 +120,8 @@ export class AzureServiceBusTopic implements IMessageTopic {
             }
             try {
                 await this.listener!.renewMessageLock(message);
-                console.log("Message lock renewed");
-            } catch (error) {
-                // @ts-ignore
+            } catch (error: any) {
+                // If the lock is lost, stop trying to renew it.
                 if (error.code === "MessageLockLost") {
                     console.error("Message lock lost; stopping renewal.");
                     clearInterval(renewalInterval);
@@ -87,6 +132,7 @@ export class AzureServiceBusTopic implements IMessageTopic {
         }, this.lockRenewalTime); // Renew lock every 30 seconds
 
         try {
+            // Process the message with the provided handler.
             await handler.onReceive(QueueMessage.from(message.body));
             await this.listener!.completeMessage(message);
         } catch (error) {
@@ -100,6 +146,9 @@ export class AzureServiceBusTopic implements IMessageTopic {
         }
     }
 
+    /**
+    * Publishes a new message to the topic.
+    */
     publish(message: QueueMessage): Promise<void> {
         return this.sender.sendMessages({ body: message });
     }

--- a/src/core/queue/providers/azure-service-bus-topic.ts
+++ b/src/core/queue/providers/azure-service-bus-topic.ts
@@ -27,13 +27,12 @@ export class AzureServiceBusTopic implements IMessageTopic {
 
     /**
     * Subscribes to the given subscription using a polling loop.
-    * Instead of breaking on AMQP or connection errors,
-    * this implementation reinitializes the receiver and continues polling.
+    * If errors occur, the receiver is recreated if necessary, and polling continues.
     */
     subscribe(subscription: string, handler: ITopicSubscription): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                // Initialize the receiver
+                // Initialize the receiver.
                 this.listener = this.sbClient.createReceiver(this.topic, subscription);
 
                 const receiveMessages = () => {
@@ -58,24 +57,19 @@ export class AzureServiceBusTopic implements IMessageTopic {
                         .catch((error: any) => {
                             console.error("Error in message processing:", error);
 
-                            // Check if the error indicates that we need to recreate the receiver.
+                            // Determine if the error requires recreating the receiver.
                             if (this.shouldRecreateReceiver(error)) {
                                 console.log("Recreating receiver due to error:", error.message);
-                                // Instead of rejecting (which would break the subscription),
-                                // we try to close the current receiver (if it's not already closed),
-                                // reinitialize it, and continue polling.
+                                // Close the current receiver if it's not already closed
                                 if (this.listener && !this.listener.isClosed) {
-                                    this.listener
-                                    .close()
-                                    .catch((closeErr) =>
-                                        console.error("Error closing listener:", closeErr)
-                                    );
+                                    this.listener.close().catch(console.error);
                                 }
-                            // Re-create the receiver to recover from connection errors.
-                            this.listener = this.sbClient.createReceiver(this.topic, subscription);
-
+                                // Re-create the receiver to recover from connection errors.
+                                this.listener = this.sbClient.createReceiver(this.topic, subscription);
+                            } else {
+                                console.error("Non-fatal error encountered, continuing polling:", error);
                             }
-                            // Optionally add a delay before retrying the polling loop.
+                            // Continue polling after a short delay.
                             setTimeout(receiveMessages, 1000);
                         });
                 };
@@ -83,28 +77,22 @@ export class AzureServiceBusTopic implements IMessageTopic {
                 receiveMessages();
                 resolve();
             } catch (error) {
-                reject(error);
+                console.error("Failed to subscribe:", error);
             }
         });
     }
 
     private shouldRecreateReceiver(error: any): boolean {
         if (!error) return false;
-        if (error.code === "GeneralError") return true; // Usually covers ECONNRESET error.
-        if (error.name === "ServiceCommunicationError") return true;
-        if (error.message?.includes("Unknown error occurred")) return true;
+        if (error.code === "GeneralError" || error.name === "ServiceCommunicationError") return true;
+        if (error.message?.includes("Unknown error occurred") || error.retryable === true) return true;
 
-        // Fallback for an unknown fatal error:
-        // e.g. look for "onDetached" or "MessagingError" in the stack or message
-        if (error.retryable === true) return true;
-
-        // Adjust logic as you see fit
-        return true
-        
+        console.warn("Unexpected error occurred, considering recreation:", error);
+        return true; // Fallback to recreating the receiver
     }
 
     /**
-    * Processes a single message with manual lock renewal.
+    * Processes a single message with manual lock renewal using a recursive setTimeout.
     */
     private async processMessageWithLockRenewal(
         message: ServiceBusReceivedMessage,
@@ -113,36 +101,38 @@ export class AzureServiceBusTopic implements IMessageTopic {
         let isProcessingComplete = false;
 
         // Using setInterval for lock renewal.
-        const renewalInterval = setInterval(async () => {
-            if (isProcessingComplete) {
-                clearInterval(renewalInterval);
-                return;
-            }
+        const renewLock = async () => {
+            if (isProcessingComplete) return;
             try {
                 await this.listener!.renewMessageLock(message);
+                // Optionally, log successful renewal.
+                // console.log("Message lock renewed");
             } catch (error: any) {
                 // If the lock is lost, stop trying to renew it.
                 if (error.code === "MessageLockLost") {
                     console.error("Message lock lost; stopping renewal.");
-                    clearInterval(renewalInterval);
+                    return;
                 } else {
                     console.error("Error renewing message lock:", error);
                 }
             }
-        }, this.lockRenewalTime); // Renew lock every 30 seconds
+            // Schedule the next renewal after lockRenewalTime.
+            setTimeout(renewLock, this.lockRenewalTime);
+        }
+        // Start lock renewal.
+        renewLock();
 
         try {
-            // Process the message with the provided handler.
+            // Process the message using the provided handler.
             await handler.onReceive(QueueMessage.from(message.body));
             await this.listener!.completeMessage(message);
         } catch (error) {
             console.error("Error processing message:", error);
             await this.listener!.abandonMessage(message);
-            // @ts-ignore
+            // @ts-ignore: Assume handler.onError can accept any error.
             await handler.onError(error);
         } finally {
-            isProcessingComplete = true; // Stop lock renewal
-            clearInterval(renewalInterval); // Ensure interval is cleared
+            isProcessingComplete = true; // Stop further lock renewals.
         }
     }
 

--- a/test/azure-service-bus-topic.unit.ts
+++ b/test/azure-service-bus-topic.unit.ts
@@ -67,34 +67,42 @@ describe('Azure service bus topic unit', () => {
         // Arrange
         const azureConfiguration = AzureQueueConfig.default();
         const azureTopic = new AzureServiceBusTopic(azureConfiguration, 'sample', 2);
-
+    
         // Mocking onReceive and onError handlers
         const onReceiveMock = jest.fn((message) => {
             console.log('Mock onReceive called with message:', message);
         });
-
+    
         const onErrorMock = jest.fn((error) => {
             console.error('Mock onError called with error:', error);
         });
-
-        // Spy on the sbClient.createReceiver to ensure it is called
+    
+        // Create a custom mock for receiveMessages:
+        // - First call: resolves with an empty array (no messages)
+        // - Subsequent calls: returns a pending promise (to stop recursion)
+        const receiveMessagesMock = jest.fn()
+            .mockImplementationOnce(() => Promise.resolve([]))
+            .mockImplementation(() => new Promise(() => {}));
+    
+        // Spy on the sbClient.createReceiver to ensure it is called and return our custom receiver mock.
         const createReceiverSpy = jest.spyOn(azureTopic['sbClient'], 'createReceiver').mockReturnValue({
-            receiveMessages: jest.fn().mockResolvedValue([]), // Simulate no messages
+            receiveMessages: receiveMessagesMock,
             close: jest.fn(),
+            isClosed: false,
         } as unknown as ServiceBusReceiver);
-
+    
         // Act
         await azureTopic.subscribe('sample', {
             onReceive: onReceiveMock,
             onError: onErrorMock,
         });
-
+    
         // Assert
         expect(createReceiverSpy).toHaveBeenCalledTimes(1);
         expect(createReceiverSpy).toHaveBeenCalledWith('sample', 'sample'); // Verify arguments
         expect(onReceiveMock).not.toHaveBeenCalled(); // No messages, so onReceive should not be called
         expect(onErrorMock).not.toHaveBeenCalled(); // No errors, so onError should not be called
-
+    
         // Cleanup
         createReceiverSpy.mockRestore();
     });


### PR DESCRIPTION
- Fixed Issue-[1703](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/1703)
- Introduced a new helper method `shouldRecreateReceiver` that inspects errors (e.g., `GeneralError`, `ServiceCommunicationError`, errors containing "Unknown error occurred", or when `retryable` is true) to determine if the receiver should be reinitialized. This change ensures that transient or fatal connection errors do not break the polling loop.
- Instead of rejecting the promise on errors (which would break the subscription), the updated logic:
  - Logs the error.
  - Checks if the error related to connection then receiver re-creation via `shouldRecreateReceiver`.
  - Closes the existing receiver if needed and then reinitializes it.
  - Continues polling after a short delay (1 second) to maintain uninterrupted message processing.
- Changed the lock renewal interval from 30 seconds to 25 seconds. This provides a safer margin to renew locks before they expire.
- The calling of `subscribe` and `publish` methods remain unchanged.
- Updated CHANGELOG.md

**Tested locally with the script using old code vs new code. Tested it switching off the wifi and after 30-40 seconds switch on the wifi  -**


```nodejs
import { Core } from "./core";
import { Queue, QueueMessage, When } from "./core/queue";
import { CoreConfig } from "./models/config";

require('dotenv').config()

function randint(min: number, max: number): number {
    return Math.floor(Math.random() * (max - min + 1)) + min;
}

let coreConfig = new CoreConfig("Azure");
Core.initialize(coreConfig);

const delay = (ms: number) => new Promise(res => setTimeout(res, ms));

const topic = 'temp-anuj';
const subscription = 'handle';
const topicObject = Core.getTopic(topic, null, 2);

const topic_subscribe = async () => {
    topicObject.subscribe(subscription, {
        onReceive: processMessage,
        onError: processError
    });
};

const publish_topic = async () => {
    await topicObject.publish(QueueMessage.from({
        message: "Hello there from local",
        data: { 'a': randint(10, 50) }
    }));
};

const processMessage = async (message: QueueMessage) => {
    console.log("Received Message:", message.toJSON());
    await delay(40 * 1000)
    return Promise.resolve();
}

const processError = (error: any) =>  {
    console.log("Received error:", error);
    return Promise.reject();
}

// Corrected Loop
(async () => {
    await topic_subscribe()
//     await Promise.all(Array.from({ length: 20 }, () => publish_topic()));
//     console.log("All messages published. Exiting...");
//     process.exit(0);  // <-- Ensures Node.js process terminates
})();
```


**Previous Code, if the WiFi was turned off, the application would throw an error and stop receiving messages. When the WiFi was restored, the receiver did not resume message processing automatically. See the logs below -** 

```
Error in message processing: ServiceBusError: GeneralError: ENOTFOUND: getaddrinfo ENOTFOUND tdei-service-bus.servicebus.windows.net
    at translateServiceBusError (/Users/anuj/Work/Gaussian/TDEI-node-ms-core/node_modules/@azure/service-bus/src/serviceBusError.ts:174:12)
    at /Users/anuj/Work/Gaussian/TDEI-node-ms-core/node_modules/@azure/service-bus/src/receivers/receiver.ts:398:13
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  retryable: false,
  code: 'GeneralError',
  errno: -3008,
  syscall: 'getaddrinfo'
}

```

**With the updated code, if the WiFi is turned off, an error is thrown, but the receiver continues attempting to receive messages. However, due to the lack of internet connectivity, it cannot fetch new messages. Once the WiFi is restored, the receiver successfully resumes message processing. See the logs below -** 
```
Error in message processing: ServiceBusError: GeneralError: ENOTFOUND: getaddrinfo ENOTFOUND tdei-service-bus.servicebus.windows.net
    at translateServiceBusError (/Users/anuj/Work/Gaussian/TDEI-node-ms-core/node_modules/@azure/service-bus/src/serviceBusError.ts:174:12)
    at /Users/anuj/Work/Gaussian/TDEI-node-ms-core/node_modules/@azure/service-bus/src/receivers/receiver.ts:398:13
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  retryable: false,
  code: 'GeneralError',
  errno: -3008,
  syscall: 'getaddrinfo'
}
Recreating receiver due to error: GeneralError: ENOTFOUND: getaddrinfo ENOTFOUND tdei-service-bus.servicebus.windows.net
Received Message: {
  messageId: null,
  messageType: null,
  publishedDate: '2025-02-11T12:18:25.143Z',
  message: 'Hello there from local',
  data: { a: 33 }
}
Received Message: {
  messageId: null,
  messageType: null,
  publishedDate: '2025-02-11T12:18:25.143Z',
  message: 'Hello there from local',
  data: { a: 36 }
}

```